### PR TITLE
Add application logo path to pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,3 +74,6 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
+  
+  assets:
+   - assets/images/rimma.png


### PR DESCRIPTION
The #9 pull request only adds application logo files without adding them to the pubspec.yaml file.

This pull request patches the commit mistake by adding the specified images into pubspec.yaml file.