### PR TITLE
Remove flutter_launcher_icons from dev_dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -83,13 +83,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_launcher_icons:
-    dependency: "direct dev"
-    description:
-      name: flutter_launcher_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.9.0"
   flutter_native_splash:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,19 +34,11 @@ dev_dependencies:
     sdk: flutter
 
   flutter_native_splash: ^1.2.0
-  flutter_launcher_icons: "^0.9.0"
 
 flutter_native_splash:
   color: "#ffffff"
   image: assets/images/splash.png
 
-flutter_icons:
-  android: "launcher_icon"
-  ios: true
-  image_path: "assets/images/launcher.png"
-  image_path_ios: "assets/images/launcher.jpg"
-
-  
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
The `flutter_launcher_icons` package causes version solving failure. The application icons are already generated, therefore, the package will be removed from dev_dependencies and will be replaced with the a compatible package when needed.